### PR TITLE
Backport some NSLayoutConstraint functionality so Mortar can run on iOS7

### DIFF
--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		35BBBBFE1C6D3C600014B159 /* Mortar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BBBBF71C6D3C600014B159 /* Mortar.swift */; };
 		35BBBBFF1C6D3C600014B159 /* Array+Mortar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BBBBF81C6D3C600014B159 /* Array+Mortar.swift */; };
 		35BBBC001C6D3C600014B159 /* View+Mortar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BBBBF91C6D3C600014B159 /* View+Mortar.swift */; };
+		A05F7A1B1C7F98E300428578 /* LayoutConstraint+Mortar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05F7A1A1C7F98E300428578 /* LayoutConstraint+Mortar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		35BBBBF71C6D3C600014B159 /* Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mortar.swift; sourceTree = "<group>"; };
 		35BBBBF81C6D3C600014B159 /* Array+Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Mortar.swift"; sourceTree = "<group>"; };
 		35BBBBF91C6D3C600014B159 /* View+Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Mortar.swift"; sourceTree = "<group>"; };
+		A05F7A1A1C7F98E300428578 /* LayoutConstraint+Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LayoutConstraint+Mortar.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 				35BBBBF91C6D3C600014B159 /* View+Mortar.swift */,
 				35BBBBDC1C6D3BBD0014B159 /* Mortar.h */,
 				35BBBBDE1C6D3BBD0014B159 /* Info.plist */,
+				A05F7A1A1C7F98E300428578 /* LayoutConstraint+Mortar.swift */,
 			);
 			path = Mortar;
 			sourceTree = "<group>";
@@ -219,6 +222,7 @@
 				35BBBBFF1C6D3C600014B159 /* Array+Mortar.swift in Sources */,
 				35BBBBFB1C6D3C600014B159 /* MortarGroup.swift in Sources */,
 				35BBBBFE1C6D3C600014B159 /* Mortar.swift in Sources */,
+				A05F7A1B1C7F98E300428578 /* LayoutConstraint+Mortar.swift in Sources */,
 				35BBBC001C6D3C600014B159 /* View+Mortar.swift in Sources */,
 				35BBBBFD1C6D3C600014B159 /* MortarAttribute.swift in Sources */,
 				35BBBBFC1C6D3C600014B159 /* MortarOperators.swift in Sources */,
@@ -282,7 +286,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -324,7 +328,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Mortar/LayoutConstraint+Mortar.swift
+++ b/Mortar/LayoutConstraint+Mortar.swift
@@ -1,0 +1,63 @@
+//
+//  LayoutConstraint+Mortar.swift
+//  Mortar
+//
+//  Created by Brian Kenny on 2/25/16.
+//  Copyright © 2016 Jason Fieldman. All rights reserved.
+//
+
+public extension NSLayoutConstraint {
+
+    //! bakport of NSLayoutConstraint.active for iOS 7
+    public var m_active: Bool {
+        get {
+            if #available(iOS 8.0, *) {
+                return self.active
+            } else {
+                return (self.m_commonSuperview()?.constraints.indexOf(self) != nil)
+            }
+        }
+        set(activate) {
+            if #available(iOS 8.0, *) {
+                self.active   = activate
+            } else if let view = self.m_commonSuperview() {
+                let addOrRemove = activate ? UIView.addConstraint : UIView.removeConstraint
+                addOrRemove(view)(self)
+            }
+        }
+    }
+
+    //! bakport of NSLayoutConstraint.activateConstraints for iOS 7
+    public class func m_activateConstraints(constraints: [NSLayoutConstraint]) {
+        if #available(iOS 8.0, *) {
+            NSLayoutConstraint.activateConstraints(constraints)
+        } else {
+            constraints.forEach { $0.m_active = true }
+        }
+    }
+
+    //! bakport of NSLayoutConstraint.deactivateConstraints for iOS 7
+    public class func m_deactivateConstraints(constraints: [NSLayoutConstraint]) {
+        if #available(iOS 8.0, *) {
+            NSLayoutConstraint.deactivateConstraints(constraints)
+        } else {
+            constraints.forEach { $0.m_active = false }
+        }
+    }
+
+    //! The recomended view(generally common superview) to attach layout constraints to in iOS7
+    private func m_commonSuperview ()->UIView? {
+        if let view1 = self.firstItem as? UIView {
+            if let view2 = self.secondItem as? UIView ,
+                commonSuperview = view1.m_commonSuperview(view2) {
+                    return commonSuperview
+            } else {
+                return view1
+            }
+        } else if let view = self.secondItem as? UIView {
+            return view
+        }
+        return nil
+    }
+
+}

--- a/Mortar/Mortar.swift
+++ b/Mortar/Mortar.swift
@@ -82,29 +82,48 @@ internal enum MortarLayoutAttribute {
     
     #if os(iOS) || os(tvOS)
     func nsLayoutAttribute() -> NSLayoutAttribute? {
-        switch self {
-        case .Left:                     return .Left
-        case .Right:                    return .Right
-        case .Top:                      return .Top
-        case .Bottom:                   return .Bottom
-        case .Leading:                  return .Leading
-        case .Trailing:                 return .Trailing
-        case .Width:                    return .Width
-        case .Height:                   return .Height
-        case .CenterX:                  return .CenterX
-        case .CenterY:                  return .CenterY
-        case .Baseline:                 return .Baseline
-        case .FirstBaseline:            return .FirstBaseline
-        case .LeftMargin:               return .LeftMargin
-        case .RightMargin:              return .RightMargin
-        case .TopMargin:                return .TopMargin
-        case .BottomMargin:             return .BottomMargin
-        case .LeadingMargin:            return .LeadingMargin
-        case .TrailingMargin:           return .TrailingMargin
-        case .CenterXWithinMargins:     return .CenterXWithinMargins
-        case .CenterYWithinMargins:     return .CenterYWithinMargins
-        case .NotAnAttribute:           return .NotAnAttribute
-        default:                        return nil
+        if #available(iOS 8.0, *) {
+            switch self {
+            case .Left:                     return .Left
+            case .Right:                    return .Right
+            case .Top:                      return .Top
+            case .Bottom:                   return .Bottom
+            case .Leading:                  return .Leading
+            case .Trailing:                 return .Trailing
+            case .Width:                    return .Width
+            case .Height:                   return .Height
+            case .CenterX:                  return .CenterX
+            case .CenterY:                  return .CenterY
+            case .Baseline:                 return .Baseline
+            case .FirstBaseline:            return .FirstBaseline
+            case .LeftMargin:               return .LeftMargin
+            case .RightMargin:              return .RightMargin
+            case .TopMargin:                return .TopMargin
+            case .BottomMargin:             return .BottomMargin
+            case .LeadingMargin:            return .LeadingMargin
+            case .TrailingMargin:           return .TrailingMargin
+            case .CenterXWithinMargins:     return .CenterXWithinMargins
+            case .CenterYWithinMargins:     return .CenterYWithinMargins
+            case .NotAnAttribute:           return .NotAnAttribute
+            default:                        return nil
+            }
+        } else {
+
+            switch self {
+            case .Left:                     return .Left
+            case .Right:                    return .Right
+            case .Top:                      return .Top
+            case .Bottom:                   return .Bottom
+            case .Leading:                  return .Leading
+            case .Trailing:                 return .Trailing
+            case .Width:                    return .Width
+            case .Height:                   return .Height
+            case .CenterX:                  return .CenterX
+            case .CenterY:                  return .CenterY
+            case .Baseline:                 return .Baseline
+            case .NotAnAttribute:           return .NotAnAttribute
+            default:                        return nil
+            }
         }
     }
     #else

--- a/Mortar/MortarConstraint.swift
+++ b/Mortar/MortarConstraint.swift
@@ -107,7 +107,7 @@ public class MortarConstraint {
                                             constant: sourceMortar.constant[i])
             
             constraint.priority = (sourceMortar.priority ?? targetMortar.priority) ?? MortarAliasLayoutPriorityDefaultNormal
-            constraint.active   = true
+            constraint.m_active = true
             layoutConstraints.append(constraint)
         }        
     }
@@ -242,12 +242,12 @@ public class MortarConstraint {
     }
     
     public func activate() -> MortarConstraint {
-        NSLayoutConstraint.activateConstraints(self.layoutConstraints)
+        NSLayoutConstraint.m_activateConstraints(self.layoutConstraints)
         return self
     }
     
     public func deactivate() -> MortarConstraint {
-        NSLayoutConstraint.deactivateConstraints(self.layoutConstraints)
+        NSLayoutConstraint.m_deactivateConstraints(self.layoutConstraints)
         return self
     }
     

--- a/Mortar/MortarGroup.swift
+++ b/Mortar/MortarGroup.swift
@@ -33,12 +33,12 @@ public typealias MortarGroup = [MortarConstraint]
 public extension Array where Element: MortarConstraint {
 
     public func activate() -> MortarGroup {
-        NSLayoutConstraint.activateConstraints(self.layoutConstraints)
+        NSLayoutConstraint.m_activateConstraints(self.layoutConstraints)
         return self
     }
     
     public func deactivate() -> MortarGroup {
-        NSLayoutConstraint.deactivateConstraints(self.layoutConstraints)
+        NSLayoutConstraint.m_deactivateConstraints(self.layoutConstraints)
         return self
     }
     

--- a/Mortar/View+Mortar.swift
+++ b/Mortar/View+Mortar.swift
@@ -62,7 +62,35 @@ public extension MortarView {
     public var m_edges:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .Edges                  ) } }
     public var m_frame:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .Frame                  ) } }
     public var m_center:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .Center                 ) } }
-    
+
+    public var m_superviews:           [UIView]         { get {
+                var ret = [self]
+                while let view  = ret.last?.superview {
+                    ret.append(view)
+                }
+            return ret.reverse()
+            }
+        }
+
+    public func m_commonSuperview(other: UIView?) -> UIView? {
+        guard let other = other else {
+            return self
+        }
+
+        let array1 = self.m_superviews
+        let array2 = other.m_superviews
+
+        var common: UIView? = nil
+        for (view1, view2) in zip(array1, array2) {
+            if (view1 == view2) {
+                common = view1
+            } else {
+                break
+            }
+        }
+        return common
+    }
+
 }
 
 #if os(iOS)


### PR DESCRIPTION
Hi Jason. Love you take on autolayout :)  I'm saddled w/ ios7 support for the foreseeable future.  Fortunately, making Mortar support iOS 7 wasn't terribly difficult. In short, this PS replaces your use of  NSLayoutConstraint's .active .activateConstraints and .deactivateConstraints w/ internal versions.  They just call through on >= 8.0, and on <8.0 they find the correct common superview & use UIView .addConstraint or .removeConstraint instead.
