### PR TITLE
Update to support Swift 2.3

### DIFF
--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -186,9 +186,11 @@
 				TargetAttributes = {
 					35BBBBD81C6D3BBD0014B159 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					35BBBBE21C6D3BBD0014B159 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -367,6 +369,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -384,6 +387,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.Mortar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -394,6 +398,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.MortarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -404,6 +409,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.MortarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Mortar/Mortar.swift
+++ b/Mortar/Mortar.swift
@@ -59,6 +59,7 @@ internal enum MortarLayoutAttribute {
     case Baseline
     #if os(iOS) || os(tvOS)
     case FirstBaseline
+    case LastBaseline
     case LeftMargin
     case RightMargin
     case TopMargin
@@ -94,8 +95,9 @@ internal enum MortarLayoutAttribute {
             case .Height:                   return .Height
             case .CenterX:                  return .CenterX
             case .CenterY:                  return .CenterY
-            case .Baseline:                 return .Baseline
+            case .Baseline:                 return .LastBaseline
             case .FirstBaseline:            return .FirstBaseline
+            case .LastBaseline:             return .LastBaseline
             case .LeftMargin:               return .LeftMargin
             case .RightMargin:              return .RightMargin
             case .TopMargin:                return .TopMargin
@@ -120,7 +122,7 @@ internal enum MortarLayoutAttribute {
             case .Height:                   return .Height
             case .CenterX:                  return .CenterX
             case .CenterY:                  return .CenterY
-            case .Baseline:                 return .Baseline
+            case .Baseline:                 return .LastBaseline
             case .NotAnAttribute:           return .NotAnAttribute
             default:                        return nil
             }
@@ -159,8 +161,9 @@ internal enum MortarLayoutAttribute {
         case .Height:                   return [.Height                                 ]
         case .CenterX:                  return [.CenterX                                ]
         case .CenterY:                  return [.CenterY                                ]
-        case .Baseline:                 return [.Baseline                               ]
+        case .Baseline:                 return [.LastBaseline                           ]
         case .FirstBaseline:            return [.FirstBaseline                          ]
+        case .LastBaseline:             return [.LastBaseline                           ]
         case .LeftMargin:               return [.LeftMargin                             ]
         case .RightMargin:              return [.RightMargin                            ]
         case .TopMargin:                return [.TopMargin                              ]


### PR DESCRIPTION
Convert all usage of .Baseline to .LastBaseline (and add .LastBaseline
to the Mortar enums) since .Baseline is being removed.

Fixes Issue #2
