### PR TITLE
Updates for GM release of Swift 3

### DIFF
--- a/Mortar/MortarConstraint.swift
+++ b/Mortar/MortarConstraint.swift
@@ -54,7 +54,7 @@ public class MortarConstraint {
         
         /* The target view must be explicitly declared */
         guard let targetView = targetMortar.item as? MortarView else {
-            NSException(name: "Target Attribute must have a defined view" as NSExceptionName,
+            NSException(name: NSExceptionName("Target Attribute must have a defined view"),
                       reason: "Target Attribute must have a defined view",
                     userInfo: nil).raise()
             return
@@ -76,7 +76,7 @@ public class MortarConstraint {
         let sourceComponents = sourceAttribute.componentAttributes()
         
         if (targetComponents.count != sourceComponents.count) {
-            NSException(name: "Attribute size mismatch" as NSExceptionName,
+            NSException(name: NSExceptionName("Attribute size mismatch"),
                       reason: "Binding two attributes of different size [left: \(targetAttribute) -> \(targetComponents.count), right: \(sourceAttribute) -> \(sourceComponents.count)]",
                     userInfo: nil).raise()
         }
@@ -85,14 +85,14 @@ public class MortarConstraint {
         
         for i in 0 ..< targetComponents.count {
             guard let tLayoutAttribute = targetComponents[i].nsLayoutAttribute() else {
-                NSException(name: "Component Attribute does not have corresponding NSLayoutAttribute" as NSExceptionName,
+                NSException(name: NSExceptionName("Component Attribute does not have corresponding NSLayoutAttribute"),
                           reason: "Component Attribute does not have corresponding NSLayoutAttribute: \(targetComponents[i])",
                         userInfo: nil).raise()
                 continue
             }
             
             guard let sLayoutAttribute = sourceComponents[i].nsLayoutAttribute() else {
-                NSException(name: "Component Attribute does not have corresponding NSLayoutAttribute" as NSExceptionName,
+                NSException(name: NSExceptionName("Component Attribute does not have corresponding NSLayoutAttribute"),
                           reason: "Component Attribute does not have corresponding NSLayoutAttribute: \(sourceComponents[i])",
                         userInfo: nil).raise()
                 continue
@@ -119,7 +119,7 @@ public class MortarConstraint {
         
         /* The target view must be explicitly declared */
         guard let targetView = target.item as? MortarView else {
-            NSException(name: "Target Attribute must have a defined view" as NSExceptionName,
+            NSException(name: NSExceptionName("Target Attribute must have a defined view"),
                       reason: "Target Attribute must have a defined view",
                     userInfo: nil).raise()
             return
@@ -127,7 +127,7 @@ public class MortarConstraint {
         
         /* For tuples, the target attribute must be explicitly declared */
         guard let targetAttribute = target.attribute else {
-            NSException(name: "Target Attribute must be defined" as NSExceptionName,
+            NSException(name: NSExceptionName("Target Attribute must be defined"),
                       reason: "Target Attribute must be defined (cannot assign tuple to view without declaring attribute)",
                     userInfo: nil).raise()
             return
@@ -136,7 +136,7 @@ public class MortarConstraint {
         let targetComponents = targetAttribute.componentAttributes()
         
         if (targetComponents.count != source.0.count) {
-            NSException(name: "Invalid component count" as NSExceptionName,
+            NSException(name: NSExceptionName("Invalid component count"),
                       reason: "Target Attribute expected component count \(targetComponents.count), source is \(source.0.count)",
                     userInfo: nil).raise()
             return
@@ -167,7 +167,7 @@ public class MortarConstraint {
             }
         } else {
             if (targetArray.count != sourceArray.count) {
-                NSException(name: "Constraining two arrays requires them to be the same length" as NSExceptionName,
+                NSException(name: NSExceptionName("Constraining two arrays requires them to be the same length"),
                           reason: "Constraining two arrays requires them to be the same length.  target: \(targetArray.count), source: \(sourceArray.count)",
                         userInfo: nil).raise()
                 return
@@ -212,7 +212,7 @@ public class MortarConstraint {
         }
         
         self.init()
-        NSException(name: "Invalid constraint pairing" as NSExceptionName,
+        NSException(name: NSExceptionName("Invalid constraint pairing"),
                   reason: "Invalid constraint pair: target: \(targetAny), source: \(sourceAny)",
                 userInfo: nil).raise()
 
@@ -229,7 +229,7 @@ public class MortarConstraint {
             }
         } else {
             if (targetAnyArray.count != sourceAnyArray.count) {
-                NSException(name: "Constraining two arrays requires them to be the same length" as NSExceptionName,
+                NSException(name: NSExceptionName("Constraining two arrays requires them to be the same length"),
                           reason: "Constraining two arrays requires them to be the same length.  target: \(targetAnyArray.count), source: \(sourceAnyArray.count)",
                         userInfo: nil).raise()
                 return

--- a/Mortar/MortarDefaultStack.swift
+++ b/Mortar/MortarDefaultStack.swift
@@ -29,8 +29,8 @@ public enum MortarDefault {
      - parameter newValue: The new value for the default.
      */
     public func setBase(_ newValue: UILayoutPriority) {
-        if !Thread.current().isMainThread {
-            NSException(name: "InvalidSetState" as NSExceptionName, reason: "Can only set state on main thread", userInfo: nil).raise()
+        if !Thread.current.isMainThread {
+            NSException(name: NSExceptionName("InvalidSetState"), reason: "Can only set state on main thread", userInfo: nil).raise()
         }
         
         switch self {
@@ -45,8 +45,8 @@ public enum MortarDefault {
      - parameter newValue: The new value for the default.
      */
     public func setBase(_ newValue: MortarLayoutPriority) {
-        if !Thread.current().isMainThread {
-            NSException(name: "InvalidSetState" as NSExceptionName, reason: "Can only set state on main thread", userInfo: nil).raise()
+        if !Thread.current.isMainThread {
+            NSException(name: NSExceptionName("InvalidSetState"), reason: "Can only set state on main thread", userInfo: nil).raise()
         }
         
         switch self {
@@ -69,15 +69,15 @@ public enum MortarDefault {
      - parameter value: The new default priority.
      */
     public func push(_ value: UILayoutPriority) {
-        if !Thread.current().isMainThread {
-            NSException(name: "InvalidPushState" as NSExceptionName, reason: "Can only push state on main thread", userInfo: nil).raise()
+        if !Thread.current.isMainThread {
+            NSException(name: NSExceptionName("InvalidPushState"), reason: "Can only push state on main thread", userInfo: nil).raise()
         }
         
         switch self {
         case .priority:
             DispatchQueue.main.async {
                 if defaultPriorityStack.count != 0 {
-                    NSException(name: "InvalidStackState" as NSExceptionName, reason: "You have unbalanced push/pop calls.", userInfo: nil).raise()
+                    NSException(name: NSExceptionName("InvalidStackState"), reason: "You have unbalanced push/pop calls.", userInfo: nil).raise()
                 }
             }
             
@@ -108,14 +108,14 @@ public enum MortarDefault {
      each corresponding push before the main event loop is re-entered.
      */
     public func pop() {
-        if !Thread.current().isMainThread {
-            NSException(name: "InvalidPopState" as NSExceptionName, reason: "Can only pop state on main thread", userInfo: nil).raise()
+        if !Thread.current.isMainThread {
+            NSException(name: NSExceptionName("InvalidPopState"), reason: "Can only pop state on main thread", userInfo: nil).raise()
         }
         
         switch self {
         case .priority:
             if defaultPriorityStack.count < 1 {
-                NSException(name: "InvalidPopState" as NSExceptionName, reason: "There is nothing on the defaults stack to pop", userInfo: nil).raise()
+                NSException(name: NSExceptionName("InvalidPopState"), reason: "There is nothing on the defaults stack to pop", userInfo: nil).raise()
             }
             
             defaultPriorityStack.removeLast()

--- a/Mortar/MortarOperators.swift
+++ b/Mortar/MortarOperators.swift
@@ -391,7 +391,7 @@ public func /(lhs: MortarAttribute, rhs: MortarCGFloatable) -> MortarAttribute {
 
 public func +(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
     if (rhs.item != nil || rhs.attribute != nil) {
-        NSException(name: "Right side of arithmetic must be constant" as NSExceptionName,
+        NSException(name: NSExceptionName("Right side of arithmetic must be constant"),
                   reason: "When performing mortar arithmetic, the right side must be a constant (cannot have view or attribute)",
                 userInfo: nil).raise()
     }
@@ -406,7 +406,7 @@ public func +(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
 
 public func -(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
     if (rhs.item != nil || rhs.attribute != nil) {
-        NSException(name: "Right side of arithmetic must be constant" as NSExceptionName,
+        NSException(name: NSExceptionName("Right side of arithmetic must be constant"),
                   reason: "When performing mortar arithmetic, the right side must be a constant (cannot have view or attribute)",
                 userInfo: nil).raise()
     }
@@ -421,7 +421,7 @@ public func -(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
 
 public func *(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
     if (rhs.item != nil || rhs.attribute != nil) {
-        NSException(name: "Right side of arithmetic must be constant" as NSExceptionName,
+        NSException(name: NSExceptionName("Right side of arithmetic must be constant"),
                   reason: "When performing mortar arithmetic, the right side must be a constant (cannot have view or attribute)",
                 userInfo: nil).raise()
     }
@@ -436,7 +436,7 @@ public func *(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
 
 public func /(lhs: MortarAttribute, rhs: MortarAttribute) -> MortarAttribute {
     if (rhs.item != nil || rhs.attribute != nil) {
-        NSException(name: "Right side of arithmetic must be constant" as NSExceptionName,
+        NSException(name: NSExceptionName("Right side of arithmetic must be constant"),
                   reason: "When performing mortar arithmetic, the right side must be a constant (cannot have view or attribute)",
                 userInfo: nil).raise()
     }
@@ -461,14 +461,14 @@ public func *(lhs: MortarCGFloatable, rhs: CGFloat) -> CGFloat {
 
 public func +(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 2) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 2",
                 userInfo: nil).raise()
         return lhs
@@ -481,14 +481,14 @@ public func +(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
 
 public func +(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 4) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 4",
                 userInfo: nil).raise()
         return lhs
@@ -503,14 +503,14 @@ public func +(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
 
 public func -(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 2) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 2",
                 userInfo: nil).raise()
         return lhs
@@ -523,14 +523,14 @@ public func -(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
 
 public func -(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 4) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 4",
                 userInfo: nil).raise()
         return lhs
@@ -545,14 +545,14 @@ public func -(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
 
 public func *(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 2) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 2",
                 userInfo: nil).raise()
         return lhs
@@ -565,14 +565,14 @@ public func *(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
 
 public func *(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 4) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 4",
                 userInfo: nil).raise()
         return lhs
@@ -587,14 +587,14 @@ public func *(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
 
 public func /(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 2) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 2",
                 userInfo: nil).raise()
         return lhs
@@ -607,14 +607,14 @@ public func /(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
 
 public func /(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 4) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 4",
                 userInfo: nil).raise()
         return lhs
@@ -631,14 +631,14 @@ infix operator ~ { precedence 140 }
 
 public func ~(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 2) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 2",
                 userInfo: nil).raise()
         return lhs
@@ -653,14 +653,14 @@ public func ~(lhs: MortarAttribute, rhs: MortarConstTwo) -> MortarAttribute {
 
 public func ~(lhs: MortarAttribute, rhs: MortarConstFour) -> MortarAttribute {
     guard let components = lhs.attribute?.componentAttributes() else {
-        NSException(name: "Attribute has no components for tuple arithmetic" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has no components for tuple arithmetic"),
                   reason: "Attribute has no components for tuple arithmetic",
                 userInfo: nil).raise()
         return lhs
     }
     
     if (components.count != 4) {
-        NSException(name: "Attribute has wrong component count" as NSExceptionName,
+        NSException(name: NSExceptionName("Attribute has wrong component count"),
                   reason: "Attribute has \(components.count) components; requires 4",
                 userInfo: nil).raise()
         return lhs


### PR DESCRIPTION
Remove parens for method call to get threads.
NSExceptionName can no longer be created via conversion from String,
so all usage must be converted into explicit constructors.
