### PR TITLE
Require only app-extension-safe API

### DIFF
--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		35BBBBEE1C6D3BBD0014B159 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -388,6 +389,7 @@
 		35BBBBEF1C6D3BBD0014B159 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This allows Mortar to be used in project that have the same flag enabled