### PR TITLE
VFL supports intrinsic content size

### DIFF
--- a/Examples/MortarVFL/MortarVFL.xcodeproj/project.pbxproj
+++ b/Examples/MortarVFL/MortarVFL.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		356F53E81E99AD3A003A6905 /* VFL_Example3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356F53E71E99AD3A003A6905 /* VFL_Example3ViewController.swift */; };
 		35E850F61E9ABC6A00EB3D86 /* VFL_Example4ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E850F51E9ABC6A00EB3D86 /* VFL_Example4ViewController.swift */; };
 		35E850FE1E9FC75C00EB3D86 /* MortarVFL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E850FD1E9FC75C00EB3D86 /* MortarVFL.swift */; };
+		A04031DB1EAEF5BF00E3398E /* VFL_Example5ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04031DA1EAEF5BE00E3398E /* VFL_Example5ViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +51,7 @@
 		356F53E71E99AD3A003A6905 /* VFL_Example3ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VFL_Example3ViewController.swift; sourceTree = "<group>"; };
 		35E850F51E9ABC6A00EB3D86 /* VFL_Example4ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VFL_Example4ViewController.swift; sourceTree = "<group>"; };
 		35E850FD1E9FC75C00EB3D86 /* MortarVFL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MortarVFL.swift; sourceTree = "<group>"; };
+		A04031DA1EAEF5BE00E3398E /* VFL_Example5ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VFL_Example5ViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +104,7 @@
 				356F53E51E99A7E0003A6905 /* VFL_Example2ViewController.swift */,
 				356F53E71E99AD3A003A6905 /* VFL_Example3ViewController.swift */,
 				35E850F51E9ABC6A00EB3D86 /* VFL_Example4ViewController.swift */,
+				A04031DA1EAEF5BE00E3398E /* VFL_Example5ViewController.swift */,
 			);
 			path = Examples;
 			sourceTree = "<group>";
@@ -224,6 +227,7 @@
 				356F53DD1E999BE3003A6905 /* MortarOperators.swift in Sources */,
 				356F53BA1E999AC8003A6905 /* AppDelegate.swift in Sources */,
 				356F53CD1E999BBE003A6905 /* Example1ViewController.swift in Sources */,
+				A04031DB1EAEF5BF00E3398E /* VFL_Example5ViewController.swift in Sources */,
 				356F53DF1E999BE3003A6905 /* MortarConstraint.swift in Sources */,
 				356F53E21E999BE3003A6905 /* NSObject+Mortar.swift in Sources */,
 				35E850FE1E9FC75C00EB3D86 /* MortarVFL.swift in Sources */,

--- a/Examples/MortarVFL/MortarVFL/Examples/VFL_Example1ViewController.swift
+++ b/Examples/MortarVFL/MortarVFL/Examples/VFL_Example1ViewController.swift
@@ -32,7 +32,7 @@ class VFL_Example1ViewController: UIViewController {
         self.view |>> v2
         self.view |>> v3
         
-        self.m_visibleRegion |^^ v1 | v2 | v3
+        self.m_visibleRegion |^^ v1[~~1] | v2[~~1] | v3[~~1]
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             print("\(self.v1.frame)")

--- a/Examples/MortarVFL/MortarVFL/Examples/VFL_Example2ViewController.swift
+++ b/Examples/MortarVFL/MortarVFL/Examples/VFL_Example2ViewController.swift
@@ -32,7 +32,7 @@ class VFL_Example2ViewController: UIViewController {
         self.view |>> ~~1 | v2[==40] | ~~2
         self.view ||>> v3
         
-        self.m_visibleRegion |^^ v1 | v2 | v3
+        self.m_visibleRegion |^^ v1[~~1] | v2[~~1] | v3[~~1]
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             print("\(self.v1.frame)")

--- a/Examples/MortarVFL/MortarVFL/Examples/VFL_Example3ViewController.swift
+++ b/Examples/MortarVFL/MortarVFL/Examples/VFL_Example3ViewController.swift
@@ -57,10 +57,10 @@ class VFL_Example3ViewController: UIViewController {
             magenta
         ]
         
-        self.view ||>> red || blue[==40] || green[~~2]
-        self.view ||>> [orange, yellow]
+        self.view ||>> red[~~1] || blue[==40] || green[~~2]
+        self.view ||>> [orange[~~1], yellow[~~1]]
         
-        self.m_visibleRegion ||^^ [red, blue, green] || orange[==44] || yellow[==44]
+        self.m_visibleRegion ||^^ [red, blue, green][~~1] || orange[==44] || yellow[==44]
         
         // Insert gray in green
         

--- a/Examples/MortarVFL/MortarVFL/Examples/VFL_Example5ViewController.swift
+++ b/Examples/MortarVFL/MortarVFL/Examples/VFL_Example5ViewController.swift
@@ -1,0 +1,96 @@
+//
+//  VFL_Example5ViewController.swift
+//  MortarVFL
+//
+//  Created by Brian Kenny on 4/24/17.
+//  Copyright © 2017 Jason Fieldman. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+//This simply a view that we can set to an arbitrary intrinsic content size.
+//It could be replaced by a label with similar results
+class MyView: UIView {
+
+    var arbitrarySize: CGSize? { didSet { invalidateIntrinsicContentSize() } }
+
+    override var intrinsicContentSize: CGSize { get { return arbitrarySize ?? super.intrinsicContentSize } }
+
+}
+
+//This VC shows a vertical layout and how intrinsic content size interacts with fixed and weighted elements when things don't fit
+class VFL_Example5ViewController: UIViewController {
+
+    var variant  = 0
+
+    let label1 = UILabel.m_create {
+        $0.textAlignment = .center
+        $0.font = UIFont.boldSystemFont(ofSize: 20)
+    }
+
+    let label2 = UILabel.m_create {
+        $0.numberOfLines = 0
+    }
+
+    let button1 = UIButton.m_create {
+        $0.setTitle("Cick Me ", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.layer.cornerRadius = 5
+        $0.layer.masksToBounds = true
+    }
+
+    let view1 = MyView.m_create {
+        $0.backgroundColor = .red
+        $0.m_compResistV = MortarAliasLayoutPriorityDefaultLow
+    }
+
+    let view2 = MyView.m_create {
+        $0.backgroundColor = .green
+    }
+
+    override func viewDidLoad() {
+        self.view.backgroundColor = .white
+
+        let allViews = [label1, label2, button1, view1, view2]
+
+        // Give everything a border so the label frames are clearly visible
+        allViews.forEach {
+            $0.layer.borderColor = UIColor.lightGray.cgColor
+            $0.layer.borderWidth = 1
+        }
+
+        self.view |+| allViews
+
+        // horizontal: pin all views between edges of m_visibleRegion with || padding(8pt) on both sides
+        m_visibleRegion ||>> allViews
+
+
+        // vertical: pin all the views in the given order with a variety of heights and spacers
+        m_visibleRegion ||^^ view1 | ~~2 | label1 || label2 | ~~1 | button1[==44] | 20 |  view2[~~1]
+
+        button1.addTarget(self, action: #selector(tap), for: .touchUpInside)
+        tap()
+
+    }
+
+    func tap() {
+        let height = variant*125 as Int
+
+        label1.text = "Variant \(variant)"
+
+        switch variant {
+        case 0: label2.text = "The red view has an intrinsic content size of 0 by 0. Because its intrinsic height is 0 it will not be visible.  The top ~~2 , middle ~~1 and bottom view2[~~1] split proportionally whatever height is not used by the constant and intrinsic sized views. Click the button to change the intrinsic content size of the red view."
+
+        case 1: label2.text = "Now we have set the red view's intrinsic content size to 0 by \(height). It will now be \(height) pt high, and the weighted views have shrunk to accomodate it. Note that it has a width because it's 0 intrinsic content width is lower prioirity than the 'm_visibleRegion ||>> allViews' constraint pinning its edges realative to its superview. No constraints have changed."
+
+        default: label2.text = "The red view has an intrinsic content size of 0 by \(height). It will now be \(height) pt high or as close to that height as possible.  If you are running on an iPhone 5 then it won't fit. In that case all the weighted spacers will have zero height and the red view, because we set its compression resistance lower than the other intrinsic views, will be less than its desired height.  All the fixed height spaces/views will be intact as they are .required"
+        }
+
+        view1.arbitrarySize = CGSize(width: 0, height: height)
+
+        variant =  variant>1 ? 0 :variant+1
+    }
+
+}

--- a/Examples/MortarVFL/MortarVFL/ListController.swift
+++ b/Examples/MortarVFL/MortarVFL/ListController.swift
@@ -16,6 +16,7 @@ class ListController: UITableViewController {
         VFL_Example2ViewController.self,
         VFL_Example3ViewController.self,
         VFL_Example4ViewController.self,
+        VFL_Example5ViewController.self,
     ]
     
     override func viewDidLoad() {


### PR DESCRIPTION
First off, great work on the VFL system.  It's far more elegant and concise than the spacer view stuff I pushed a few weeks ago.  I've finally found some free time to try it out, and there's one thing it still needed to be usefully for a lot of the situations where we were using spacer views.  Specifically, support for intrinsic content size.  Most labels, lots of images, etc. need that.  Turns out it was only about dozen lines to add support for it.  With this change views default to intrinsic content size(which is also the default in Apple's VFL) and you have to specify weights.  In practice, having used a system like this for a bit over a year, I've found most visible views tend to be either intrinsic or constant size, and most weights are used in padding. 