### PR TITLE
Infer superview & return (constraints, views)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mortar Changelog
 
+## 1.4.0 -- 5/18/17
+
+* VFL: inferred superview & capture operators return tuple of constraints and veiws 
+
 ## 1.3.0 -- 5/1/17
 
 * Changed default MortarVFL sizing to intrinsic

--- a/Examples/MortarVFL/MortarVFL/Examples/VFL_Example5ViewController.swift
+++ b/Examples/MortarVFL/MortarVFL/Examples/VFL_Example5ViewController.swift
@@ -53,26 +53,21 @@ class VFL_Example5ViewController: UIViewController {
     override func viewDidLoad() {
         self.view.backgroundColor = .white
 
-        let allViews = [label1, label2, button1, view1, view2]
-
-        // Give everything a border so the label frames are clearly visible
-        allViews.forEach {
-            $0.layer.borderColor = UIColor.lightGray.cgColor
-            $0.layer.borderWidth = 1
-        }
-
-        self.view |+| allViews
+        // vertical: pin all the views in the given order with a variety of heights and spacers
+        // note: this adds all veiws on the right as subviews of m_visibleRegion(since they don't already have a superview)
+        // the ||^^ operator returns a tuple of all the constraints and (non parrent) views, of which we only need the veiws for later work
+        let (_, allViews) = m_visibleRegion ||^^ view1 | ~~2 | label1 || label2 | ~~1 | button1[==44] | 20 |  view2[~~1]
 
         // horizontal: pin all views between edges of m_visibleRegion with || padding(8pt) on both sides
         m_visibleRegion ||>> allViews
 
-
-        // vertical: pin all the views in the given order with a variety of heights and spacers
-        m_visibleRegion ||^^ view1 | ~~2 | label1 || label2 | ~~1 | button1[==44] | 20 |  view2[~~1]
-
         button1.addTarget(self, action: #selector(tap), for: .touchUpInside)
         tap()
 
+        allViews.forEach {
+            $0.layer.borderColor = UIColor.lightGray.cgColor
+            $0.layer.borderWidth = 1
+        }
     }
 
     func tap() {

--- a/Mortar.podspec
+++ b/Mortar.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Mortar"
-  s.version      = "1.3.0"
+  s.version      = "1.4.0"
   s.summary      = "Auto Layout in Swift using concise, powerful, flexible syntax"
 
   s.description  = <<-DESC

--- a/MortarTests/MortarTests.swift
+++ b/MortarTests/MortarTests.swift
@@ -660,8 +660,6 @@ class MortarTests: XCTestCase {
         let v2 = MortarView()
         let v3 = MortarView()
         
-        v1 |+| [v2, v3]
-        
         v1.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         
         v1 |>> v2[~~1] | v3[~~1]
@@ -681,7 +679,7 @@ class MortarTests: XCTestCase {
         let v3 = MortarView()
         let v4 = MortarView()
         
-        v1 |+| [v2, v3, v4]
+        v1 |+| [v2, v3, v4] //required: view heirarchy is not inferable from VFL
         
         v1.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         v4.frame = CGRect(x: 100, y: 100, width: 100, height: 100)
@@ -705,8 +703,8 @@ class MortarTests: XCTestCase {
         let v3 = MortarView()
         let v4 = MortarView()
         let v5 = MortarView()
-        
-        v1 |+| [v2, v3, v4, v5]
+
+        v1 |+| [v2, v3, v4, v5] //required: view heirarchy is not inferable from VFL
         
         v1.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         v4.frame = CGRect(x: 100, y: 100, width: 100, height: 100)
@@ -733,8 +731,6 @@ class MortarTests: XCTestCase {
         let v1 = MortarView()
         let v2 = MortarView()
         let v3 = MortarView()
-        
-        v1 |+| [v2, v3]
         
         v1.frame = CGRect(x: 0, y: 0, width: 124, height: 124)
         
@@ -770,7 +766,6 @@ class MortarTests: XCTestCase {
         let l2size = l2.sizeThatFits(CGSize(width: 500, height: 500))
 
         c.frame = CGRect(x: 0, y: 0, width: 500, height: 500)
-        c |+| [v1, v2, v3, l1, l2, l3]
 
         c ||>> v1[~~1] || v2[~~2] || v3[==5] || l1 || l2 || l3[~~2]
         c ||^^ v1 || v2[==10] || v3[==5] || l1 || l2 || l3[==20]
@@ -816,7 +811,6 @@ class MortarTests: XCTestCase {
         label.numberOfLines = 0
         label.lineBreakMode = .byCharWrapping
 
-        c |+| [label]
         c.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
 
         c |>> 50 | label | 50
@@ -841,6 +835,26 @@ class MortarTests: XCTestCase {
         XCTAssertEqualWithAccuracy(label.frame.size.height, lineHeight * ceil(lineLength2/50), accuracy: 1, "Right indent")
         XCTAssertEqualWithAccuracy(label.frame.origin.y, 150 - label.frame.origin.y - label.frame.size.height, accuracy: 1, "top/bottom pad are equal")
         XCTAssertGreaterThan(label.frame.size.height, originalHeight, "four line label shoudl be taller than 3 line label")
+    }
+
+    func testVFL7() {
+        let v1 = MortarView()
+        let v2 = MortarView()
+        let v3 = MortarView()
+        let v4 = MortarView()
+        let v5 = MortarView()
+
+        v2 |+| v3
+
+        v1 |> v2 | v3
+        v4 ^! v1
+        v4 ||^^ v5
+        v1.layoutIfNeeded()
+
+        XCTAssertEqual(v2.superview, v1, "VFL should infer v2's superview")
+        XCTAssertEqual(v3.superview, v2, "VFL should not infer v3's superview as it is already set")
+        XCTAssertEqual(v4.superview, v1, "VFL should infer v4's superview")
+        XCTAssertEqual(v5.superview, v4, "VFL should infer v5's superview")
     }
 
     #if os(iOS)

--- a/README.md
+++ b/README.md
@@ -629,6 +629,52 @@ viewB[==44] || viewC[==88] ^! viewA.m_top
 
 Again, note the use of the ```!``` bang symbol for trailing single-ended statements, and that there are no weight-based nodes.  Leading single-ended statements use the operator with the pipe: ```|>```
 
+### Inferred Superview
+Mortar VFL will attempt to infer a superview for all nodes which do not have one at the time constraints are created. Generally this will be the leading capture view or, when not present, the trailing capture view. 
+
+```swift
+self.view |+| [v1,  v2, v3]	 //This line can be omited
+self.view |>> v1 | v2 | v3
+
+self.view |+| [v1,  v2, v3]	 //This line can be omited
+self.view |> v1 | v2 | v3
+
+// The |+| line can't be omitted here because the inferred
+// superview is v1, which is probably not what you wanted
+self.view |+| [v1,  v2, v3]	 
+v1.m_right |>  | v2 | v3
+
+```
+### Return Values
+The capture operators(```|^^, |^, |>```, etc) return a 2 tuple with named elements containing mortar constraints and views. The former is usefull for modifying constraints at a later time.  The later can be convenient to reduce code repetition.
+
+```swift
+// Using destructuring
+let (c, v) = self.view |>> v1 | v2 | v3
+// c will be a set of constraints
+// v will be the array [v1, v2, v3]
+
+// Using element names  
+let r = self.view |^ v1 || v2 || v3
+self.view |>> 20 | r.views | 20
+
+// A complex example formatted for better readability. 
+// This adds 4 views to self.view(via inferred superview).
+// It constrains them vertically with padding and some heights.
+// It constrains them horizontally to fill self.view minus 20pt margins.
+(self.view |^^ 20 
+           | someView 
+           | 10 
+           | someOtherView 
+           | 10 
+           | yetAnotherView[==50]
+           | ~~1
+           | bottomButton[==44]
+           | 20
+).views |=| self.view.m_sides ~ (20, 20)
+
+```
+ 
 ## Examples
 
 There are several examples of MortarVFL in the Examples/MortarVFL project.


### PR DESCRIPTION
This PS does 2 things.  It lets regular view nodes opt into the inferred superview logic that's currently used for ghost views, in the case where they don't have a superview when constraints are created. This often gets rid of the need to ad subviews explicitly.  Second, all the capture list operators go from returning just the constraints to  returning a tuple of the constraints and the views.  I've been converting all my spacerview code to mortarVFL, and almost every case we have something like 
```
let theViews = [v1, v2, .........]
self.view |+| theViews
self.view |^^ v1 | v2 | .......
theViews.m_...

//Which now becomes something like

let theViews = (self.view |^^ v1 | v2 ........).views
theViews.m_....
```
It only saves 2 lines, but one of those is re-writing the array in a different form, which is tedious and error prone.
