### PR TITLE
Add the _NoCreatable subspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mortar Changelog
 
+## 1.4.0.3 -- 4/7/18
+
+* Added Core_NoCreatable and MortarVFL_NoCreatable subspecs
+
 ## 1.4.0.2 -- 2/16/18
 
 * Added swift_version to podspec

--- a/Extensions/MortarVFL/MortarVFL.swift
+++ b/Extensions/MortarVFL/MortarVFL.swift
@@ -66,17 +66,17 @@ public enum _MortarSizingType {
 
 /// Return a completely non-interactive view for layout purposes
 private func mGhostView(in parent: MortarView?) -> _MortarVFLGhostView {
-    return _MortarVFLGhostView.m_create {
-        #if os(iOS) || os(tvOS)
-        $0.backgroundColor = .clear
-        $0.alpha = 0
-        $0.isUserInteractionEnabled = false
-        #else
-        $0.wantsLayer = true
-        $0.layer?.backgroundColor = CGColor.init(red: 0, green: 0, blue: 0, alpha: 0)
-        #endif
-        parent?.addSubview($0)
-    }
+    let ghostView = _MortarVFLGhostView()
+    #if os(iOS) || os(tvOS)
+    ghostView.backgroundColor = .clear
+    ghostView.alpha = 0
+    ghostView.isUserInteractionEnabled = false
+    #else
+    ghostView.wantsLayer = true
+    ghostView.layer?.backgroundColor = CGColor.init(red: 0, green: 0, blue: 0, alpha: 0)
+    #endif
+    parent?.addSubview(ghostView)
+    return ghostView
 }
 
 /// Class override so that it is visible in UI interactive view as a ghost

--- a/Mortar.podspec
+++ b/Mortar.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Mortar"
-  s.version      = "1.4.0.2"
+  s.version      = "1.4.0.3"
   s.summary      = "Auto Layout in Swift using concise, powerful, flexible syntax"
 
   s.description  = <<-DESC
@@ -31,6 +31,16 @@ Pod::Spec.new do |s|
   s.subspec 'MortarVFL' do |ss|
     ss.source_files = "Extensions/MortarVFL/*.swift"
     ss.dependency 'Mortar/Core'
+  end
+
+  s.subspec 'Core_NoCreatable' do |ss|
+    ss.source_files = "Mortar/*.swift"
+    ss.exclude_files = "Mortar/NSObject+Mortar.swift"
+  end
+
+  s.subspec 'MortarVFL_NoCreatable' do |ss|
+    ss.source_files = "Extensions/MortarVFL/*.swift"
+    ss.dependency 'Mortar/Core_NoCreatable'
   end
 
 end

--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		355FCD251DAFDD3F0095C596 /* NSObject+Mortar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355FCD241DAFDD3F0095C596 /* NSObject+Mortar.swift */; };
 		35A31A8B1CCBACCA007E1068 /* MortarDefaultStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A31A8A1CCBACCA007E1068 /* MortarDefaultStack.swift */; };
+		35AE20B420794C71001F77C4 /* MortarCreatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE20B320794C71001F77C4 /* MortarCreatable.swift */; };
 		35BBBBDD1C6D3BBD0014B159 /* Mortar.h in Headers */ = {isa = PBXBuildFile; fileRef = 35BBBBDC1C6D3BBD0014B159 /* Mortar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35BBBBE41C6D3BBD0014B159 /* Mortar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35BBBBD91C6D3BBD0014B159 /* Mortar.framework */; };
 		35BBBBE91C6D3BBD0014B159 /* MortarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BBBBE81C6D3BBD0014B159 /* MortarTests.swift */; };
@@ -44,6 +45,7 @@
 		35964B251CBE8E6700E54D22 /* CONTRIBUTORS.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTORS.md; sourceTree = SOURCE_ROOT; };
 		35964B261CBE8E6700E54D22 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		35A31A8A1CCBACCA007E1068 /* MortarDefaultStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MortarDefaultStack.swift; sourceTree = "<group>"; };
+		35AE20B320794C71001F77C4 /* MortarCreatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MortarCreatable.swift; sourceTree = "<group>"; };
 		35BBBBD91C6D3BBD0014B159 /* Mortar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mortar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		35BBBBDC1C6D3BBD0014B159 /* Mortar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Mortar.h; sourceTree = "<group>"; };
 		35BBBBDE1C6D3BBD0014B159 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				35964B261CBE8E6700E54D22 /* LICENSE */,
 				35BBBBF71C6D3C600014B159 /* Mortar.swift */,
 				35BBBBF61C6D3C600014B159 /* MortarAttribute.swift */,
+				35AE20B320794C71001F77C4 /* MortarCreatable.swift */,
 				35BBBBF51C6D3C600014B159 /* MortarOperators.swift */,
 				35A31A8A1CCBACCA007E1068 /* MortarDefaultStack.swift */,
 				35BBBBF31C6D3C600014B159 /* MortarConstraint.swift */,
@@ -265,6 +268,7 @@
 				35BBBBFB1C6D3C600014B159 /* MortarGroup.swift in Sources */,
 				35BBBBFE1C6D3C600014B159 /* Mortar.swift in Sources */,
 				35A31A8B1CCBACCA007E1068 /* MortarDefaultStack.swift in Sources */,
+				35AE20B420794C71001F77C4 /* MortarCreatable.swift in Sources */,
 				355FCD251DAFDD3F0095C596 /* NSObject+Mortar.swift in Sources */,
 				35BBBC001C6D3C600014B159 /* View+Mortar.swift in Sources */,
 				35BBBBFD1C6D3C600014B159 /* MortarAttribute.swift in Sources */,

--- a/Mortar.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Mortar.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Mortar/MortarCreatable.swift
+++ b/Mortar/MortarCreatable.swift
@@ -1,0 +1,33 @@
+//
+//  NSObject+Mortar.swift
+//  Mortar
+//
+//  Created by Jason Fieldman on 10/13/16.
+//  Copyright © 2016 Jason Fieldman. All rights reserved.
+//
+
+import Foundation
+
+/// This protocol declares that the object can be instantiated with a
+/// parameter-less initializer
+public protocol MortarCreatable {
+    init()
+}
+
+/// Implement the create() static function for NSObjectCreatable
+public extension MortarCreatable {
+    
+    /// Instantiates an instance of the receiving NSObject and
+    /// calls the creation function on it.
+    ///
+    /// - parameter creatorFunc: A function that takes the newly
+    ///                          created instance and performs any
+    ///                          desired configuration on it.
+    ///
+    /// - returns: The newly created instance.
+    public static func m_create(creatorFunc: (Self) -> Void) -> Self {
+        let retval = self.init()
+        creatorFunc(retval)
+        return retval
+    }
+}

--- a/Mortar/NSObject+Mortar.swift
+++ b/Mortar/NSObject+Mortar.swift
@@ -8,34 +8,15 @@
 
 import Foundation
 
-
-
-/// This protocol declares that the object can be instantiated with a
-/// parameter-less initializer
-public protocol MortarNSObjectCreatable {
-    init()
-}
-
-/// An NSObject, and those inheriting from it, can be instantiated
-/// without parameters.
-extension NSObject: MortarNSObjectCreatable { }
-
-
-/// Implement the create() static function for NSObjectCreatable
-public extension MortarNSObjectCreatable {
-    
-    
-    /// Instantiates an instance of the receiving NSObject and
-    /// calls the creation function on it.
-    ///
-    /// - parameter creatorFunc: A function that takes the newly
-    ///                          created instance and performs any
-    ///                          desired configuration on it.
-    ///
-    /// - returns: The newly created instance.
-    public static func m_create(creatorFunc: (Self) -> Void) -> Self {
-        let retval = self.init()
-        creatorFunc(retval)
-        return retval
-    }
-}
+/// Provides default MortarCreatable support for all NSObject-based
+/// classes.  This is included in the default Mortar spec for backwards
+/// compatibility but may break codebases that contain class definitions
+/// that do not always wish to expose init().  For those codebases
+/// they should use:
+///
+/// pod 'Mortar/Core_NoCreatable'
+///
+/// and can put this code to allow m_create to be used on classes:
+///
+/// extension (your-class-name): MortarCreatable { }
+extension NSObject: MortarCreatable { }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ pod 'Mortar', '~> 0.11' # Swift 2.3
 pod 'Mortar', '~> 0.10' # Swift 2.2
 ```
 
+### Disabling MortarCreatable
+
+The default implementation of Mortar declares a MortarCreatable protocol (m_create), which in recent versions of
+swift causes problems with classes that do not expose the default init() method.
+
+Until the next major release, you can use:
+
+```ruby
+pod 'Mortar/Core_NoCreatable'
+pod 'Mortar/MortarVFL_NoCreatable'
+```
+
+To install a version of Mortar that does not attach this protocol to NSObject.  You can then gain access to
+m_create for whatever classes you want, with:
+
+```ruby
+extension your_class_name: MortarCreatable { }
+```
+
 # Usage
 
 Mortar does not require closures of any kind.  The Mortar operators (```|=|```, ```|>|``` and ```|<|```) instantiate and return constraints that are activated by default.  


### PR DESCRIPTION
Adding Core_NoCreatable and MortarVFL_NoCreatable subspecs for those that do not want NSObject to extend MortarCreatable by default

Ref: https://github.com/jmfieldman/Mortar/issues/23