### PR TITLE
Swift 4.2 and 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     env: SWIFT_VERSION=5.0
 before_install:
   - gem install xcpretty -N
-  - gem install cocoapods -v '1.5.3'
+  - gem install cocoapods -v '1.7.0'
 script:
   - set -o pipefail
   - sed -i '' -e "s/^SWIFT_VERSION *=.*/SWIFT_VERSION = $SWIFT_VERSION/g" Mortar/Mortar.xcconfig MortarTests/MortarTests.xcconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: objective-c
-osx_image: xcode10.1
 branches:
   only:
     - master
-env:
-  - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
+matrix:
+  include:
+  - osx_image: xcode10.1
+    env: SWIFT_VERSION=4.2
+  - osx_image: xcode10.2
+    env: SWIFT_VERSION=5.0
 before_install:
   - gem install xcpretty -N
   - gem install cocoapods -v '1.5.3'
 script:
   - set -o pipefail
-  - xcodebuild -project Mortar.xcodeproj -scheme "Mortar iOS" -sdk "iphonesimulator12.1"
+  - sed -i '' -e "s/^SWIFT_VERSION *=.*/SWIFT_VERSION = $SWIFT_VERSION/g" Mortar/Mortar.xcconfig MortarTests/MortarTests.xcconfig
+  - xcodebuild -project Mortar.xcodeproj -scheme "Mortar iOS" -sdk "iphonesimulator"
     -destination "OS=12.1,name=iPhone 6S" ONLY_ACTIVE_ARCH=NO  test | xcpretty -c
   - pod lib lint --quick

--- a/Extensions/MortarVFL/MortarVFL.swift
+++ b/Extensions/MortarVFL/MortarVFL.swift
@@ -212,7 +212,7 @@ public prefix func ==(floatable: MortarCGFloatable) -> _MortarSizingNode {
 // MARK: - Mortar view subscript -> VFL Node
 
 public extension MortarView {
-    public subscript(sizingNode: _MortarSizingNode) -> _MortarVFLNode {
+    subscript(sizingNode: _MortarSizingNode) -> _MortarVFLNode {
         return _MortarVFLNode(views: [self], sizingNode: sizingNode)
     }
 }
@@ -220,11 +220,11 @@ public extension MortarView {
 // MARK: - Making an array of MortarView with size -> VFL Node
 
 public extension Array where Element: MortarView {
-    public subscript(sizingNode: _MortarSizingNode) -> _MortarVFLNode {
+    subscript(sizingNode: _MortarSizingNode) -> _MortarVFLNode {
         return _MortarVFLNode(views: self, sizingNode: sizingNode)
     }
     
-    public func __asNode() -> _MortarVFLNode {
+    func __asNode() -> _MortarVFLNode {
         return _MortarVFLNode(views: self, sizingNode: _MortarSizingNode(floatable: 1, sizingType: .intrinsic))
     }
 }
@@ -841,7 +841,7 @@ private func raise(_ reason: String) throws {
 
 fileprivate extension _MortarVFLListCapture {
     
-    fileprivate func toGroup() throws -> MortarGroup {
+    func toGroup() throws -> MortarGroup {
         // Accumulate the constraints
         var result: MortarGroup = MortarGroup()
         
@@ -1093,7 +1093,7 @@ public extension UIViewController {
     /// Creates a _MortarVFLGhostView that is sized between the
     /// view controller's guide anchors.
     /// Will reuse the existing one if it exists, based on tag lookup
-    public var m_visibleRegion: MortarView {
+    var m_visibleRegion: MortarView {
         for view in self.view.subviews {
             if view.tag != UIViewController.kVisibleRegionGhostTag {
                 continue

--- a/Mortar.podspec
+++ b/Mortar.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
-  s.swift_version = "4.2"
+  s.swift_version = '5.0'
+  s.swift_versions = ['4.2', '5.0'] if s.respond_to?(:swift_versions) # Cocoapods >=1.7.0
 
   s.source = { :git => "https://github.com/jmfieldman/Mortar.git", :tag => "#{s.version}" }
   s.source_files = "Mortar/*.swift"

--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		35BBBBF81C6D3C600014B159 /* Array+Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Mortar.swift"; sourceTree = "<group>"; };
 		35BBBBF91C6D3C600014B159 /* View+Mortar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Mortar.swift"; sourceTree = "<group>"; };
 		35E850F91E9FC23700EB3D86 /* MortarVFL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MortarVFL.swift; sourceTree = "<group>"; };
+		6ACDE9222297665800BA7A1C /* Mortar.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Mortar.xcconfig; sourceTree = "<group>"; };
+		6ACDE924229766F600BA7A1C /* MortarTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MortarTests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 				355FCD241DAFDD3F0095C596 /* NSObject+Mortar.swift */,
 				35BBBBDC1C6D3BBD0014B159 /* Mortar.h */,
 				35BBBBDE1C6D3BBD0014B159 /* Info.plist */,
+				6ACDE9222297665800BA7A1C /* Mortar.xcconfig */,
 			);
 			path = Mortar;
 			sourceTree = "<group>";
@@ -131,6 +134,7 @@
 			isa = PBXGroup;
 			children = (
 				35BBBBE81C6D3BBD0014B159 /* MortarTests.swift */,
+				6ACDE924229766F600BA7A1C /* MortarTests.xcconfig */,
 				35BBBBEA1C6D3BBD0014B159 /* Info.plist */,
 			);
 			path = MortarTests;
@@ -214,17 +218,17 @@
 				TargetAttributes = {
 					35BBBBD81C6D3BBD0014B159 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 					};
 					35BBBBE21C6D3BBD0014B159 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 35BBBBD31C6D3BBD0014B159 /* Build configuration list for PBXProject "Mortar" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -407,6 +411,7 @@
 		};
 		35BBBBEE1C6D3BBD0014B159 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6ACDE9222297665800BA7A1C /* Mortar.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -423,13 +428,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
 		35BBBBEF1C6D3BBD0014B159 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6ACDE9222297665800BA7A1C /* Mortar.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -445,32 +449,28 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.Mortar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
 		35BBBBF11C6D3BBD0014B159 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6ACDE924229766F600BA7A1C /* MortarTests.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = MortarTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.MortarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
 		35BBBBF21C6D3BBD0014B159 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6ACDE924229766F600BA7A1C /* MortarTests.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = MortarTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.fieldman.MortarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Jason Fieldman";
 				TargetAttributes = {
 					35BBBBD81C6D3BBD0014B159 = {

--- a/Mortar.xcodeproj/xcshareddata/xcschemes/Mortar iOS.xcscheme
+++ b/Mortar.xcodeproj/xcshareddata/xcschemes/Mortar iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Mortar/Array+Mortar.swift
+++ b/Mortar/Array+Mortar.swift
@@ -23,38 +23,38 @@
 
 
 public extension Array where Element: MortarView {
-    
-    public var m_left:                  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .left                   }); return z }
-    public var m_right:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .right                  }); return z }
-    public var m_top:                   [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .top                    }); return z }
-    public var m_bottom:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .bottom                 }); return z }
-    public var m_leading:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leading                }); return z }
-    public var m_trailing:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .trailing               }); return z }
-    public var m_width:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .width                  }); return z }
-    public var m_height:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .height                 }); return z }
-    public var m_centerX:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerX                }); return z }
-    public var m_centerY:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerY                }); return z }
-    public var m_baseline:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .baseline               }); return z }
+
+    var m_left:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .left                   }); return z }
+    var m_right:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .right                  }); return z }
+    var m_top:                  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .top                    }); return z }
+    var m_bottom:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .bottom                 }); return z }
+    var m_leading:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leading                }); return z }
+    var m_trailing:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .trailing               }); return z }
+    var m_width:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .width                  }); return z }
+    var m_height:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .height                 }); return z }
+    var m_centerX:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerX                }); return z }
+    var m_centerY:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerY                }); return z }
+    var m_baseline:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .baseline               }); return z }
     #if os(iOS) || os(tvOS)
-    public var m_firstBaseline:         [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .firstBaseline          }); return z }
-    public var m_leftMargin:            [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leftMargin             }); return z }
-    public var m_rightMargin:           [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .rightMargin            }); return z }
-    public var m_topMargin:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .topMargin              }); return z }
-    public var m_bottomMargin:          [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .bottomMargin           }); return z }
-    public var m_leadingMargin:         [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leadingMargin          }); return z }
-    public var m_trailingMargin:        [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .trailingMargin         }); return z }
-    public var m_centerXWithinMargin:   [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerXWithinMargins   }); return z }
-    public var m_centerYWithinMargin:   [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerYWithinMargins   }); return z }
+    var m_firstBaseline:        [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .firstBaseline          }); return z }
+    var m_leftMargin:           [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leftMargin             }); return z }
+    var m_rightMargin:          [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .rightMargin            }); return z }
+    var m_topMargin:            [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .topMargin              }); return z }
+    var m_bottomMargin:         [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .bottomMargin           }); return z }
+    var m_leadingMargin:        [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .leadingMargin          }); return z }
+    var m_trailingMargin:       [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .trailingMargin         }); return z }
+    var m_centerXWithinMargin:  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerXWithinMargins   }); return z }
+    var m_centerYWithinMargin:  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .centerYWithinMargins   }); return z }
     #endif
-    public var m_sides:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .sides                  }); return z }
-    public var m_caps:                  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .caps                   }); return z }
-    public var m_size:                  [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .size                   }); return z }
-    public var m_cornerTL:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerTL               }); return z }
-    public var m_cornerTR:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerTR               }); return z }
-    public var m_cornerBL:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerBL               }); return z }
-    public var m_cornerBR:              [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerBR               }); return z }
-    public var m_edges:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .edges                  }); return z }
-    public var m_frame:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .frame                  }); return z }
-    public var m_center:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .center                 }); return z }
+    var m_sides:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .sides                  }); return z }
+    var m_caps:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .caps                   }); return z }
+    var m_size:                 [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .size                   }); return z }
+    var m_cornerTL:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerTL               }); return z }
+    var m_cornerTR:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerTR               }); return z }
+    var m_cornerBL:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerBL               }); return z }
+    var m_cornerBR:             [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .cornerBR               }); return z }
+    var m_edges:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .edges                  }); return z }
+    var m_frame:                [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .frame                  }); return z }
+    var m_center:               [MortarAttribute] { let z = self.map({ $0.m_intoAttribute() }); z.forEach({$0.attribute = .center                 }); return z }
     
 }

--- a/Mortar/Mortar.xcconfig
+++ b/Mortar/Mortar.xcconfig
@@ -1,0 +1,24 @@
+//
+//  Mortar
+//
+//  Copyright (c) 2016-Present Jason Fieldman - https://github.com/jmfieldman/Mortar
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+SWIFT_VERSION = 4.2

--- a/Mortar/MortarCreatable.swift
+++ b/Mortar/MortarCreatable.swift
@@ -25,7 +25,7 @@ public extension MortarCreatable {
     ///                          desired configuration on it.
     ///
     /// - returns: The newly created instance.
-    public static func m_create(creatorFunc: (Self) -> Void) -> Self {
+    static func m_create(creatorFunc: (Self) -> Void) -> Self {
         let retval = self.init()
         creatorFunc(retval)
         return retval

--- a/Mortar/MortarGroup.swift
+++ b/Mortar/MortarGroup.swift
@@ -33,18 +33,18 @@ public typealias MortarGroup = [MortarConstraint]
 public extension Array where Element: MortarConstraint {
 
     @discardableResult
-    public func activate() -> MortarGroup {
+    func activate() -> MortarGroup {
         NSLayoutConstraint.activate(self.layoutConstraints)
         return self
     }
     
     @discardableResult
-    public func deactivate() -> MortarGroup {
+    func deactivate() -> MortarGroup {
         NSLayoutConstraint.deactivate(self.layoutConstraints)
         return self
     }
     
-    public var layoutConstraints: [NSLayoutConstraint] {
+    var layoutConstraints: [NSLayoutConstraint] {
         var response: [NSLayoutConstraint] = []
         self.forEach {
             response += $0.layoutConstraints
@@ -53,14 +53,14 @@ public extension Array where Element: MortarConstraint {
     }
     
     @discardableResult
-    public func replace(with newConstraints: MortarGroup) -> MortarGroup {
+    func replace(with newConstraints: MortarGroup) -> MortarGroup {
         self.deactivate()
         newConstraints.activate()
         return newConstraints
     }
     
     @discardableResult
-    public func changePriority(to newPriority: MortarCGFloatable) -> MortarGroup {
+    func changePriority(to newPriority: MortarCGFloatable) -> MortarGroup {
         for constraint in self {
             constraint.changePriority(to: newPriority)
         }
@@ -68,7 +68,7 @@ public extension Array where Element: MortarConstraint {
     }
     
     @discardableResult
-    public func changePriority(to newPriority: MortarAliasLayoutPriority) -> MortarGroup {
+    func changePriority(to newPriority: MortarAliasLayoutPriority) -> MortarGroup {
         for constraint in self {
             constraint.changePriority(to: newPriority)
         }
@@ -76,7 +76,7 @@ public extension Array where Element: MortarConstraint {
     }
     
     @discardableResult
-    public func changePriority(to newPriority: MortarLayoutPriority) -> MortarGroup {
+    func changePriority(to newPriority: MortarLayoutPriority) -> MortarGroup {
         for constraint in self {
             constraint.changePriority(to: newPriority)
         }

--- a/Mortar/View+Mortar.swift
+++ b/Mortar/View+Mortar.swift
@@ -32,52 +32,52 @@ public extension MortarView {
     
     // -------- Mortar Attributes --------
     
-    public var m_left:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .left                   ) } }
-    public var m_right:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .right                  ) } }
-    public var m_top:                   MortarAttribute { get { return MortarAttribute(item: self, attribute: .top                    ) } }
-    public var m_bottom:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottom                 ) } }
-    public var m_leading:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .leading                ) } }
-    public var m_trailing:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailing               ) } }
-    public var m_width:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .width                  ) } }
-    public var m_height:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .height                 ) } }
-    public var m_centerX:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerX                ) } }
-    public var m_centerY:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerY                ) } }
-    public var m_baseline:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .baseline               ) } }
+    var m_left:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .left                   ) } }
+    var m_right:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .right                  ) } }
+    var m_top:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .top                    ) } }
+    var m_bottom:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottom                 ) } }
+    var m_leading:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .leading                ) } }
+    var m_trailing:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailing               ) } }
+    var m_width:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .width                  ) } }
+    var m_height:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .height                 ) } }
+    var m_centerX:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerX                ) } }
+    var m_centerY:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerY                ) } }
+    var m_baseline:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .baseline               ) } }
     #if os(iOS) || os(tvOS)
-    public var m_firstBaseline:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .firstBaseline          ) } }
-    public var m_leftMargin:            MortarAttribute { get { return MortarAttribute(item: self, attribute: .leftMargin             ) } }
-    public var m_rightMargin:           MortarAttribute { get { return MortarAttribute(item: self, attribute: .rightMargin            ) } }
-    public var m_topMargin:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .topMargin              ) } }
-    public var m_bottomMargin:          MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottomMargin           ) } }
-    public var m_leadingMargin:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .leadingMargin          ) } }
-    public var m_trailingMargin:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailingMargin         ) } }
-    public var m_centerXWithinMargin:   MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerXWithinMargins   ) } }
-    public var m_centerYWithinMargin:   MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerYWithinMargins   ) } }
+    var m_firstBaseline:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .firstBaseline          ) } }
+    var m_leftMargin:           MortarAttribute { get { return MortarAttribute(item: self, attribute: .leftMargin             ) } }
+    var m_rightMargin:          MortarAttribute { get { return MortarAttribute(item: self, attribute: .rightMargin            ) } }
+    var m_topMargin:            MortarAttribute { get { return MortarAttribute(item: self, attribute: .topMargin              ) } }
+    var m_bottomMargin:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottomMargin           ) } }
+    var m_leadingMargin:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .leadingMargin          ) } }
+    var m_trailingMargin:       MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailingMargin         ) } }
+    var m_centerXWithinMargin:  MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerXWithinMargins   ) } }
+    var m_centerYWithinMargin:  MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerYWithinMargins   ) } }
     #endif
-    public var m_sides:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .sides                  ) } }
-    public var m_caps:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .caps                   ) } }
-    public var m_size:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .size                   ) } }
-    public var m_cornerTL:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTL               ) } }
-    public var m_cornerTR:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTR               ) } }
-    public var m_cornerBL:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBL               ) } }
-    public var m_cornerBR:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBR               ) } }
-    public var m_edges:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .edges                  ) } }
-    public var m_frame:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .frame                  ) } }
-    public var m_center:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .center                 ) } }
+    var m_sides:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .sides                  ) } }
+    var m_caps:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .caps                   ) } }
+    var m_size:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .size                   ) } }
+    var m_cornerTL:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTL               ) } }
+    var m_cornerTR:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTR               ) } }
+    var m_cornerBL:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBL               ) } }
+    var m_cornerBR:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBR               ) } }
+    var m_edges:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .edges                  ) } }
+    var m_frame:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .frame                  ) } }
+    var m_center:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .center                 ) } }
     
     // -------- Compression Resistance --------
     
-    public var m_compResistH: MortarAliasLayoutPriorityAble {
+    var m_compResistH: MortarAliasLayoutPriorityAble {
         set { self.setContentCompressionResistancePriority(newValue.m_intoPriority(), for: .horizontal) }
         get { return self.contentCompressionResistancePriority(for: .horizontal) }
     }
     
-    public var m_compResistV: MortarAliasLayoutPriorityAble {
+    var m_compResistV: MortarAliasLayoutPriorityAble {
         set { self.setContentCompressionResistancePriority(newValue.m_intoPriority(), for: .vertical) }
         get { return self.contentCompressionResistancePriority(for: .vertical) }
     }
     
-    public var m_compResist: MortarAliasLayoutPriorityAble {
+    var m_compResist: MortarAliasLayoutPriorityAble {
         set {
             self.setContentCompressionResistancePriority(newValue.m_intoPriority(), for: .horizontal)
             self.setContentCompressionResistancePriority(newValue.m_intoPriority(), for: .vertical)
@@ -90,17 +90,17 @@ public extension MortarView {
     
     // -------- Content Hugging --------
     
-    public var m_huggingH: MortarAliasLayoutPriorityAble {
+    var m_huggingH: MortarAliasLayoutPriorityAble {
         set { self.setContentHuggingPriority(newValue.m_intoPriority(), for: .horizontal) }
         get { return self.contentHuggingPriority(for: .horizontal) }
     }
     
-    public var m_huggingV: MortarAliasLayoutPriorityAble {
+    var m_huggingV: MortarAliasLayoutPriorityAble {
         set { self.setContentHuggingPriority(newValue.m_intoPriority(), for: .vertical) }
         get { return self.contentHuggingPriority(for: .vertical) }
     }
     
-    public var m_hugging: MortarAliasLayoutPriorityAble {
+    var m_hugging: MortarAliasLayoutPriorityAble {
         set {
             self.setContentHuggingPriority(newValue.m_intoPriority(), for: .horizontal)
             self.setContentHuggingPriority(newValue.m_intoPriority(), for: .vertical)
@@ -115,49 +115,49 @@ public extension MortarView {
 
 #if os(iOS)
 public extension UIViewController {
-    public var m_topLayoutGuideTop:       MortarAttribute { return MortarAttribute(item: self.topLayoutGuide,    attribute: .top)    }
-    public var m_topLayoutGuideBottom:    MortarAttribute { return MortarAttribute(item: self.topLayoutGuide,    attribute: .bottom) }
-    public var m_bottomLayoutGuideTop:    MortarAttribute { return MortarAttribute(item: self.bottomLayoutGuide, attribute: .top)    }
-    public var m_bottomLayoutGuideBottom: MortarAttribute { return MortarAttribute(item: self.bottomLayoutGuide, attribute: .bottom) }
+    var m_topLayoutGuideTop:        MortarAttribute { return MortarAttribute(item: self.topLayoutGuide,    attribute: .top)    }
+    var m_topLayoutGuideBottom:     MortarAttribute { return MortarAttribute(item: self.topLayoutGuide,    attribute: .bottom) }
+    var m_bottomLayoutGuideTop:     MortarAttribute { return MortarAttribute(item: self.bottomLayoutGuide, attribute: .top)    }
+    var m_bottomLayoutGuideBottom:  MortarAttribute { return MortarAttribute(item: self.bottomLayoutGuide, attribute: .bottom) }
 }
 #endif
 
 #if os(iOS) || os(tvOS)
-    public extension UILayoutGuide {
-        
-        // -------- Mortar Attributes --------
-        
-        public var m_left:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .left                   ) } }
-        public var m_right:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .right                  ) } }
-        public var m_top:                   MortarAttribute { get { return MortarAttribute(item: self, attribute: .top                    ) } }
-        public var m_bottom:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottom                 ) } }
-        public var m_leading:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .leading                ) } }
-        public var m_trailing:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailing               ) } }
-        public var m_width:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .width                  ) } }
-        public var m_height:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .height                 ) } }
-        public var m_centerX:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerX                ) } }
-        public var m_centerY:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerY                ) } }
-        public var m_baseline:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .baseline               ) } }
-        #if os(iOS) || os(tvOS)
-        public var m_firstBaseline:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .firstBaseline          ) } }
-        public var m_leftMargin:            MortarAttribute { get { return MortarAttribute(item: self, attribute: .leftMargin             ) } }
-        public var m_rightMargin:           MortarAttribute { get { return MortarAttribute(item: self, attribute: .rightMargin            ) } }
-        public var m_topMargin:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .topMargin              ) } }
-        public var m_bottomMargin:          MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottomMargin           ) } }
-        public var m_leadingMargin:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .leadingMargin          ) } }
-        public var m_trailingMargin:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailingMargin         ) } }
-        public var m_centerXWithinMargin:   MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerXWithinMargins   ) } }
-        public var m_centerYWithinMargin:   MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerYWithinMargins   ) } }
-        #endif
-        public var m_sides:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .sides                  ) } }
-        public var m_caps:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .caps                   ) } }
-        public var m_size:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .size                   ) } }
-        public var m_cornerTL:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTL               ) } }
-        public var m_cornerTR:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTR               ) } }
-        public var m_cornerBL:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBL               ) } }
-        public var m_cornerBR:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBR               ) } }
-        public var m_edges:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .edges                  ) } }
-        public var m_frame:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .frame                  ) } }
-        public var m_center:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .center                 ) } }
-    }
+public extension UILayoutGuide {
+
+    // -------- Mortar Attributes --------
+
+    var m_left:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .left                   ) } }
+    var m_right:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .right                  ) } }
+    var m_top:                  MortarAttribute { get { return MortarAttribute(item: self, attribute: .top                    ) } }
+    var m_bottom:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottom                 ) } }
+    var m_leading:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .leading                ) } }
+    var m_trailing:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailing               ) } }
+    var m_width:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .width                  ) } }
+    var m_height:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .height                 ) } }
+    var m_centerX:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerX                ) } }
+    var m_centerY:              MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerY                ) } }
+    var m_baseline:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .baseline               ) } }
+    #if os(iOS) || os(tvOS)
+    var m_firstBaseline:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .firstBaseline          ) } }
+    var m_leftMargin:           MortarAttribute { get { return MortarAttribute(item: self, attribute: .leftMargin             ) } }
+    var m_rightMargin:          MortarAttribute { get { return MortarAttribute(item: self, attribute: .rightMargin            ) } }
+    var m_topMargin:            MortarAttribute { get { return MortarAttribute(item: self, attribute: .topMargin              ) } }
+    var m_bottomMargin:         MortarAttribute { get { return MortarAttribute(item: self, attribute: .bottomMargin           ) } }
+    var m_leadingMargin:        MortarAttribute { get { return MortarAttribute(item: self, attribute: .leadingMargin          ) } }
+    var m_trailingMargin:       MortarAttribute { get { return MortarAttribute(item: self, attribute: .trailingMargin         ) } }
+    var m_centerXWithinMargin:  MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerXWithinMargins   ) } }
+    var m_centerYWithinMargin:  MortarAttribute { get { return MortarAttribute(item: self, attribute: .centerYWithinMargins   ) } }
+    #endif
+    var m_sides:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .sides                  ) } }
+    var m_caps:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .caps                   ) } }
+    var m_size:                 MortarAttribute { get { return MortarAttribute(item: self, attribute: .size                   ) } }
+    var m_cornerTL:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTL               ) } }
+    var m_cornerTR:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerTR               ) } }
+    var m_cornerBL:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBL               ) } }
+    var m_cornerBR:             MortarAttribute { get { return MortarAttribute(item: self, attribute: .cornerBR               ) } }
+    var m_edges:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .edges                  ) } }
+    var m_frame:                MortarAttribute { get { return MortarAttribute(item: self, attribute: .frame                  ) } }
+    var m_center:               MortarAttribute { get { return MortarAttribute(item: self, attribute: .center                 ) } }
+}
 #endif

--- a/MortarTests/MortarTests.xcconfig
+++ b/MortarTests/MortarTests.xcconfig
@@ -1,0 +1,24 @@
+//
+//  Mortar
+//
+//  Copyright (c) 2016-Present Jason Fieldman - https://github.com/jmfieldman/Mortar
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+SWIFT_VERSION = 4.2


### PR DESCRIPTION
This makes Mortar compatible to Swift 4.2 and 5.0.
* test on Travis that it compiles with Swift 4.2 and 5.0
* fix all Xcode 10.2 warnings
* Podspec:
  * use `swift_versions` to define both supported Swift versions (introduced in Cocoapods 1.7.0)
  * upgrade `swift_version` to 5.0 (backwards compatibility for Cocoapods < 1.7.0)

Tested integrations:
* Xcode 10.0, Swift 4.2, Cocoapods 1.5.3 Podfile post_install: `config.build_settings['SWIFT_VERSION'] = '4.0'`
* Xcode 10.0, Swift 4.2, Cocoapods 1.7.0, Podfile: `supports_swift_versions '4.2'`, no post_install
* Xcode 10.2, Swift 4.2, Cocoapods 1.7.0, Podfile: `supports_swift_versions '>= 4.2', '< 5.0'`, no post_install
* Xcode 10.2, Swift 5.0, Cocoapods 1.7.0, Podfile: `supports_swift_versions '>= 4.2', '<= 5.0'`, no post_install